### PR TITLE
add h2 database by default in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ docker run -d \
 -e KEYCLOAK_USER=admin \
 -e KEYCLOAK_PASSWORD=admin \
 -e KEYCLOAK_IMPORT=/tmp/konveyor-realm.json \
+-e DB_VENDOR=h2 \
 -v $(pwd)/konveyor-realm.json:/tmp/konveyor-realm.json \
 quay.io/keycloak/keycloak:12.0.2
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       KEYCLOAK_USER: admin
       KEYCLOAK_PASSWORD: admin
       KEYCLOAK_IMPORT: /tmp/konveyor-realm.json
+      DB_VENDOR: h2
     volumes:
       - ./konveyor-realm.json:/tmp/konveyor-realm.json:z
     healthcheck:


### PR DESCRIPTION
When Keycloak runs inside a docker container it runs really slow unless the database provider is defined with ENV variables