### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -128,7 +128,7 @@ jobs:
           yarn install
           yarn build
       - name: Push to Quay.io
-        uses: elgohr/Publish-Docker-Github-Action@3.02
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           registry: quay.io
           name: carlosthe19916/controls-ui

--- a/.github/workflows/test-containers.yml
+++ b/.github/workflows/test-containers.yml
@@ -21,7 +21,7 @@ jobs:
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
       - name: Push to GitHub Packages
-        uses: elgohr/Publish-Docker-Github-Action@3.02
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           registry: docker.pkg.github.com
           name: ${{ github.repository_owner }}/${{ github.event.repository.name }}/tackle-ui


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore